### PR TITLE
Run ansible-playbook.yml only on the main branch

### DIFF
--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -1,6 +1,9 @@
 name: Run ansible-playbook on macOS
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - 'main'
 
 jobs:
   integration:


### PR DESCRIPTION
# What

* Run ansible-playbook.yml only on the main branch

# Why

* It takes about 9 mins to finish the CI job. It's too long to run the job every time a new commit is pushed.