### PR TITLE
Updates on Jan 9, 2022

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -55,6 +55,7 @@ homebrew_cask_packages:
   - skitch
   - slack
   - spotify
+  - stats
   - tunnelblick
   - visual-studio-code
   - xbar


### PR DESCRIPTION
# What

- Add stats to the homebrew cask packages

# Why

- Show the stats on the menubar
﻿
