### PR TITLE
feat: add a step to launch tmate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install test dependencies
         run: pip3 install -r requirements.dev.txt
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Lint code
         run: |
           yamllint .


### PR DESCRIPTION
# What

* Fix https://github.com/shotarok/macos-provisioning/runs/4754482889?check_suite_focus=true

# Why

* Make all CI jobs green