### PR TITLE
Updates on Feb 2, 2022

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -51,6 +51,7 @@ homebrew_cask_packages:
   - homebrew/cask-drivers/gopro-webcam
   - karabiner-elements
   - licecap
+  - miniconda
   - notion
   - rectangle
   - skitch


### PR DESCRIPTION
# What

* Add miniconda to the cask packages

# Why

* Enable to manage anaconda packages + python version through miniconda