### PR TITLE
Revert "Updates on Feb 2, 2022"

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -53,7 +53,6 @@ homebrew_cask_packages:
   - homebrew/cask-drivers/gopro-webcam
   - karabiner-elements
   - licecap
-  - miniconda
   - notion
   - rectangle
   - skitch


### PR DESCRIPTION
# What

Reverts shotarok/macos-provisioning#34

# Why

GitHub Action failed due to the error:'macOS's Gatekeeper has been disabled for this Cask'.