### PR TITLE
Update macos runner's versions

### DIFF
--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-10.15
+          - macos-12 # macOS Monterey
+          - macos-11 # macOS Big Sur
 
     steps:
       - name: Check out the codebase


### PR DESCRIPTION
# What

* Update macOS runner's versions

# Why

* macOS Catalina 10.15 is deprecated on GitHub Action
