### PR TITLE
Update macOS workflow to use macos-latest

### DIFF
--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-12 # macOS Monterey
-          - macos-11 # macOS Big Sur
+          - macos-latest
 
     steps:
       - name: Check out the codebase


### PR DESCRIPTION
## Summary
• Replace specific macOS versions (macos-12, macos-11) with macos-latest
• Simplifies maintenance by automatically using the latest available macOS runner

## Test plan
- [ ] Verify workflow runs successfully on macos-latest
- [ ] Confirm ansible playbook execution works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)