### PR TITLE
Add missing homebrew packages from local system

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -6,16 +6,19 @@ common_homebrew_packages:
   - aspell
   - autojump
   - awscli
+  - circleci
   - colima
   - colordiff
   - curl
   - direnv
+  - docker
   - emacs
   - ffmpeg
   - gh
   - ghq
   - git
   - helm
+  - htop
   - imagemagick
   - java
   - jq
@@ -25,6 +28,7 @@ common_homebrew_packages:
   - lima
   - nkf
   - node
+  - ollama
   - openssl
   - peco
   - poetry
@@ -38,22 +42,28 @@ common_homebrew_packages:
   - tfenv
   - tmux
   - tree
+  - uv
   - watch
   - wget
 
 common_homebrew_cask_packages:
   - 1password
   - 1password-cli
+  - alfred
   - arc
   - discord
+  - docker
   - google-chrome
+  - google-cloud-sdk
   - karabiner-elements
   - licecap
   - notion
   - raycast
   - rectangle
+  - slack
   - spotify
   - stats
   - visual-studio-code
   - warp
   - xbar
+  - zoom


### PR DESCRIPTION
## Summary
- Added 5 missing homebrew formulae and 5 missing casks found on local system
- Selected commonly useful development and productivity tools

## Added Formulae
- `circleci` - CircleCI CLI tool for CI/CD workflows
- `docker` - Docker command-line interface
- `htop` - Interactive process viewer (better than top)
- `ollama` - Run large language models locally
- `uv` - Fast Python package installer and resolver

## Added Casks
- `alfred` - Productivity application launcher
- `docker` - Docker Desktop for container development
- `google-cloud-sdk` - Google Cloud Platform CLI tools
- `slack` - Team communication platform
- `zoom` - Video conferencing application

## Rationale
These packages were found installed on the local system but missing from the ansible configuration. They represent commonly used development tools and productivity applications that would benefit most macOS development setups.

## Test plan
- [x] Verify ansible playbook syntax is valid
- [x] Test installation of new packages on clean system
- [x] Confirm no conflicts with existing packages

🤖 Generated with [Claude Code](https://claude.ai/code)