### PR TITLE
Set up Mergify for automated PR merging

### DIFF
--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -1,8 +1,8 @@
 name: Run ansible-playbook on macOS
 
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request:
+    types: [labeled]
   schedule:
     - cron: '0 18 1 * *' # Run at 6 pm UTC / 10 am PT on 1st every month
   workflow_dispatch:
@@ -16,7 +16,7 @@ jobs:
   integration:
     name: Integration Test
     runs-on: ${{ matrix.os }}
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ready-to-merge'
     strategy:
       matrix:
         os:

--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -1,9 +1,8 @@
 name: Run ansible-playbook on macOS
 
 on:
-  push:
-    branches:
-      - 'main'
+  pull_request_review:
+    types: [submitted]
   schedule:
     - cron: '0 18 1 * *' # Run at 6 pm UTC / 10 am PT on 1st every month
   workflow_dispatch:
@@ -17,6 +16,7 @@ jobs:
   integration:
     name: Integration Test
     runs-on: ${{ matrix.os }}
+    if: github.event.review.state == 'approved'
     strategy:
       matrix:
         os:

--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -63,3 +63,15 @@ jobs:
         env:
           ANSIBLE_FORCE_COLOR: '1'
 
+      - name: Remove ready-to-merge label on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'ready-to-merge'
+            })
+

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,10 +18,9 @@ pull_request_rules:
         name: default
         method: merge
 
-  - name: add to merge queue when CI passes after approval
+  - name: add label when approved to trigger CI
     conditions:
       - "#approved-reviews-by>=1"
-      - "status-success=Integration Test"
       - "-label=ready-to-merge"
       - "-draft"
     actions:
@@ -38,12 +37,12 @@ pull_request_rules:
         remove:
           - "ready-to-merge"
 
-  - name: automatic merge for dependabot after approval
+  - name: add label for dependabot when approved
     conditions:
       - "author=dependabot[bot]"
       - "#approved-reviews-by>=1"
-      - "status-success=Integration Test"
+      - "-label=ready-to-merge"
     actions:
-      queue:
-        name: default
-        method: merge
+      label:
+        add:
+          - "ready-to-merge"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,48 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "status-success=Integration Test"
+      - "label=ready-to-merge"
+    merge_conditions:
+      - "status-success=Integration Test"
+
+pull_request_rules:
+  - name: automatic merge on CI success and approval
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "status-success=Integration Test"
+      - "label=ready-to-merge"
+    actions:
+      queue:
+        name: default
+        method: merge
+
+  - name: add to merge queue when ready
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "status-success=Integration Test"
+      - "-label=ready-to-merge"
+      - "-draft"
+    actions:
+      label:
+        add:
+          - "ready-to-merge"
+
+  - name: remove from queue on changes
+    conditions:
+      - "label=ready-to-merge"
+      - "-status-success=Integration Test"
+    actions:
+      label:
+        remove:
+          - "ready-to-merge"
+
+  - name: automatic merge for dependabot
+    conditions:
+      - "author=dependabot[bot]"
+      - "status-success=Integration Test"
+    actions:
+      queue:
+        name: default
+        method: merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,7 +18,7 @@ pull_request_rules:
         name: default
         method: merge
 
-  - name: add to merge queue when ready
+  - name: add to merge queue when CI passes after approval
     conditions:
       - "#approved-reviews-by>=1"
       - "status-success=Integration Test"
@@ -29,7 +29,7 @@ pull_request_rules:
         add:
           - "ready-to-merge"
 
-  - name: remove from queue on changes
+  - name: remove from queue on CI failure
     conditions:
       - "label=ready-to-merge"
       - "-status-success=Integration Test"
@@ -38,9 +38,10 @@ pull_request_rules:
         remove:
           - "ready-to-merge"
 
-  - name: automatic merge for dependabot
+  - name: automatic merge for dependabot after approval
     conditions:
       - "author=dependabot[bot]"
+      - "#approved-reviews-by>=1"
       - "status-success=Integration Test"
     actions:
       queue:


### PR DESCRIPTION
## Summary
- Replace GitHub merge queue with Mergify for automated PR merging
- Configure label-based CI triggers to control when expensive tests run
- Add automatic label management for failed CI runs

## Changes
- Add `.mergify.yml` configuration with merge queue rules
- Update `ansible-playbook.yml` to trigger on `ready-to-merge` label
- Remove GitHub merge queue configuration
- Add `ready-to-merge` label for workflow management
- Auto-remove label on CI failure to prevent broken merges

## Workflow
1. PR approved → Mergify adds `ready-to-merge` label
2. Label triggers ansible-playbook CI
3. If CI passes → Mergify queues and merges PR
4. If CI fails → label removed, PR blocked from merge

🤖 Generated with [Claude Code](https://claude.ai/code)