### PR TITLE
Update homebrew packages

### DIFF
--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -6,7 +6,6 @@ common_homebrew_packages:
   - aspell
   - autojump
   - awscli
-  - bazel
   - chezmoi
   - circleci
   - colima

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -6,6 +6,8 @@ common_homebrew_packages:
   - aspell
   - autojump
   - awscli
+  - bazel
+  - chezmoi
   - circleci
   - colima
   - colordiff
@@ -16,6 +18,8 @@ common_homebrew_packages:
   - gh
   - ghq
   - git
+  - go
+  - gmailctl
   - helm
   - htop
   - imagemagick
@@ -50,10 +54,15 @@ common_homebrew_cask_packages:
   - 1password-cli
   - alfred
   - arc
+  - calibre
+  - chatgpt
+  - claude
+  - cursor
   - discord
-  - docker
+  - docker-desktop
+  - gcloud-cli
+  - ghostty
   - google-chrome
-  - google-cloud-sdk
   - karabiner-elements
   - licecap
   - notion


### PR DESCRIPTION
## Summary

Update the homebrew packages in the playbook to sync with current macOS configuration:

### Added Formula Packages
- bazel
- chezmoi
- go
- gmailctl

### Added Cask Packages
- calibre
- chatgpt
- claude
- cursor
- docker-desktop (replaced docker)
- gcloud-cli (replaced google-cloud-sdk)
- ghostty

This PR aligns the provisioning playbook with the currently installed applications.